### PR TITLE
$(form).values() doesn't support multiple select

### DIFF
--- a/src/minified-web-full-src.js
+++ b/src/minified-web-full-src.js
@@ -2708,7 +2708,16 @@ define('minified', function() {
 				// @condend
 				// @cond !ie9compatibility $(el['elements'])['values'](r);
 			else if (n && (!/ox|io/i.test(el['type']) || el['checked'])) { // ox|io => short for checkbox, radio
-				r[n] = r[n] == _null ? v : collector(flexiEach, [r[n], v], nonOp);
+				if(el['tagName'] == 'SELECT') {
+					var oa = [];
+					$(el.children).each(function(item){
+						if(item.selected)
+							oa.push(item.value);
+					});
+					r[n] = (oa.length > 1 ? oa : oa[0] || '');
+				} else {
+					r[n] = r[n] == _null ? v : collector(flexiEach, [r[n], v], nonOp);
+				}
 			}
 		});
 		return r;


### PR DESCRIPTION
The documentation for the values function says if there are multiple results for a  name it will return an array and that seems to work for checkboxen and the like but not for selects. I have confirmed this in IE7+ and A grade browsers.